### PR TITLE
fix ts compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^8.0.31",
     "@types/numeral": "^0.0.22",
     "@types/react": "^16.0.7",
-    "@types/react-dom": "^15.5.4",
+    "@types/react-dom": "^16.0.2",
     "@types/react-router-dom": "^4.0.8",
     "LykkeFramework": "^0.3.40",
     "compass-mixins": "0.12.10",


### PR DESCRIPTION
Error during `npm start`:
```
node_modules\@types\react-dom\node_modules\@types\react\index.d.ts
(3421,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'a' must be of typ
e 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>', but here has type 'DetailedH
TMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
```

Updated `@types/react-dom` to `16.0.2` version