### PR TITLE
Forbid doubleclick on action buttons

### DIFF
--- a/src/components/CreateWalletForm/index.tsx
+++ b/src/components/CreateWalletForm/index.tsx
@@ -57,9 +57,7 @@ export class WalletForm extends React.Component<WalletFormProps> {
             className="btn btn--primary pull-right"
             type="button"
             onClick={this.handleSubmit}
-            disabled={
-              !this.props.wallet.isValid || this.props.wallet.isUpdating
-            }
+            disabled={!this.props.wallet.isValid || this.props.wallet.updating}
           >
             Generate API Key
           </button>

--- a/src/components/CreateWalletForm/index.tsx
+++ b/src/components/CreateWalletForm/index.tsx
@@ -57,7 +57,9 @@ export class WalletForm extends React.Component<WalletFormProps> {
             className="btn btn--primary pull-right"
             type="button"
             onClick={this.handleSubmit}
-            disabled={!this.props.wallet.isValid}
+            disabled={
+              !this.props.wallet.isValid || this.props.wallet.isUpdating
+            }
           >
             Generate API Key
           </button>

--- a/src/components/TransferForm/index.tsx
+++ b/src/components/TransferForm/index.tsx
@@ -81,6 +81,7 @@ export const TransferForm: React.SFC<TransferFormProps> = ({
   const handleSubmit = async (e: any) => {
     e.preventDefault();
     try {
+      transfer.isUpdating = true;
       const id = await transfer.sendTransfer();
       if (!!id) {
         toggleQrWindow();
@@ -91,6 +92,8 @@ export const TransferForm: React.SFC<TransferFormProps> = ({
       setTimeout(() => {
         uiStore.transferError = '';
       }, 3000);
+    } finally {
+      transfer.isUpdating = false;
     }
   };
 
@@ -204,7 +207,7 @@ export const TransferForm: React.SFC<TransferFormProps> = ({
           type="submit"
           value="Submit"
           className="btn btn--primary"
-          disabled={!transfer.canTransfer}
+          disabled={!transfer.canTransfer || transfer.isUpdating}
           onClick={handleSubmit}
         />
         <Link to={ROUTE_WALLETS} className="btn btn--flat">

--- a/src/models/transferModel.ts
+++ b/src/models/transferModel.ts
@@ -10,6 +10,8 @@ export class TransferModel {
   @observable amount: number = 0;
   @observable asset: AssetModel;
 
+  @observable isUpdating: boolean = false;
+
   @observable amountInBaseCurrency: number;
 
   @computed

--- a/src/models/walletModel.ts
+++ b/src/models/walletModel.ts
@@ -51,6 +51,8 @@ export class WalletModel {
     return !!this.title.trim();
   }
 
+  @observable isUpdating: boolean = false;
+
   constructor(private readonly store: WalletStore, dto?: any) {
     this.updateFromJson(dto);
     reaction(

--- a/src/models/walletModel.ts
+++ b/src/models/walletModel.ts
@@ -51,8 +51,6 @@ export class WalletModel {
     return !!this.title.trim();
   }
 
-  @observable isUpdating: boolean = false;
-
   constructor(private readonly store: WalletStore, dto?: any) {
     this.updateFromJson(dto);
     reaction(

--- a/src/stores/walletStore.ts
+++ b/src/stores/walletStore.ts
@@ -71,17 +71,23 @@ export class WalletStore {
 
   createApiWallet = async (wallet: WalletModel) => {
     const {title, desc} = wallet;
-    wallet.isUpdating = true;
-    const dto = await this.api!.createApiWallet(title, desc);
-    wallet.isUpdating = false;
-    const newWallet = this.createWallet({
-      ApiKey: dto.ApiKey,
-      Id: dto.WalletId
-    });
-    this.addWallet(
-      extendObservable(newWallet, {title, desc, type: WalletType.Trusted})
-    );
-    return newWallet;
+    wallet.updating = true;
+    try {
+      const dto = await this.api!.createApiWallet(title, desc);
+      const newWallet = this.createWallet({
+        ApiKey: dto.ApiKey,
+        Id: dto.WalletId
+      });
+      this.addWallet(
+        extendObservable(newWallet, {title, desc, type: WalletType.Trusted})
+      );
+      return Promise.resolve(newWallet);
+    } catch (error) {
+      this.rootStore.uiStore.apiError = error;
+      return Promise.reject(error);
+    } finally {
+      wallet.updating = true;
+    }
   };
 
   findWalletById = (id: string) => this.wallets.find(w => w.id === id);

--- a/src/stores/walletStore.ts
+++ b/src/stores/walletStore.ts
@@ -71,7 +71,9 @@ export class WalletStore {
 
   createApiWallet = async (wallet: WalletModel) => {
     const {title, desc} = wallet;
+    wallet.isUpdating = true;
     const dto = await this.api!.createApiWallet(title, desc);
+    wallet.isUpdating = false;
     const newWallet = this.createWallet({
       ApiKey: dto.ApiKey,
       Id: dto.WalletId


### PR DESCRIPTION
@optimusway 
For Wallet I use in walletStore same approach as in uiStore.
As for TransferForm I mentioned uiStore.transferError and choose to use same simple uiStore.isTransfering instead of use transferStore.