### PR TITLE
WEB-259, Add "redirect to path" support in Oauth authentication flow.

### DIFF
--- a/src/pages/AuthPage/index.tsx
+++ b/src/pages/AuthPage/index.tsx
@@ -2,7 +2,6 @@ import {inject, observer} from 'mobx-react';
 import * as React from 'react';
 import {RouteComponentProps} from 'react-router-dom';
 import {RootStoreProps} from '../../App';
-import {ROUTE_ROOT} from '../../constants/routes';
 import {STORE_ROOT} from '../../constants/stores';
 import {AuthUtils} from '../../utils';
 
@@ -21,7 +20,7 @@ export class AuthPage extends React.Component<AuthPageProps> {
     if (accessToken) {
       this.authStore
         .fetchToken(accessToken, state)
-        .then(() => this.props.history.push(ROUTE_ROOT));
+        .then((route: string) => this.props.history.push(route));
     } else {
       this.authStore.signIn();
     }


### PR DESCRIPTION
Currently when a user goes from [trade.lykke.com](http://trade.lykke.com) to [wallet.lykke.com](http://wallet.lykke.com), he always redirected to `/` in wallet. This is a problem for the new kyc flow because we need to redirect him to [wallet.lykke.com/profile/kyc](http://wallet.lykke.com/profile/kyc).

With this commit, I'm sending encoded `pathname` to auth server and then parsing back for redirection.

I've used `state` parameter of flow. Because `redirect_uri` doesn't accept query parameters and we need to redirect user to `/auth` page after successful login in current flow (in order to get access token). So using `state` was the only way without much refactoring.
